### PR TITLE
Also accept image references within the image attribute

### DIFF
--- a/examples/advanced/src/main.rs
+++ b/examples/advanced/src/main.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
         repository
             .full_name
             .ok_or(anyhow!("Failed to get full name"))?,
-        repository.url.to_string()
+        repository.url
     );
 
     groupend!();

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
         repository
             .full_name
             .ok_or(anyhow!("Failed to get full name"))?,
-        repository.url.to_string()
+        repository.url
     );
 
     groupend!();

--- a/examples/installer/src/main.rs
+++ b/examples/installer/src/main.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
         repository
             .full_name
             .ok_or(anyhow!("Failed to get full name"))?,
-        repository.url.to_string()
+        repository.url
     );
 
     groupend!();

--- a/ghactions-core/src/actions/models.rs
+++ b/ghactions-core/src/actions/models.rs
@@ -88,7 +88,7 @@ impl Default for ActionYML {
 
 impl ActionYML {
     /// Set the Action to a Container Image based Action
-    pub fn set_container_image(&mut self, image: PathBuf) {
+    pub fn set_container_image(&mut self, image: String) {
         self.runs.using = ActionRunUsing::Docker;
         self.runs.image = Some(image);
         self.runs.steps = None;
@@ -317,7 +317,7 @@ pub struct ActionRuns {
 
     /// Container Image (container actions only)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub image: Option<PathBuf>,
+    pub image: Option<String>,
     /// Arguments (container actions only)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub args: Option<Vec<String>>,

--- a/ghactions-core/src/logging.rs
+++ b/ghactions-core/src/logging.rs
@@ -100,7 +100,6 @@ macro_rules! group {
 /// # fn foo() {
 /// groupend!();
 /// # }
-
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! groupend {

--- a/ghactions-core/src/toolcache/archives.rs
+++ b/ghactions-core/src/toolcache/archives.rs
@@ -1,4 +1,6 @@
 //! # ToolCache Archives
+#[cfg(not(feature = "toolcache-zip"))]
+use std::path::Path;
 use std::path::PathBuf;
 
 use crate::ActionsError;
@@ -128,7 +130,7 @@ impl ToolCache {
     ///
     /// For native support, the `toolcache-zip` feature must be enabled.
     #[cfg(not(feature = "toolcache-zip"))]
-    async fn extract_zip(&self, zipfile: &PathBuf, output: &PathBuf) -> Result<(), ActionsError> {
+    async fn extract_zip(&self, zipfile: &Path, output: &PathBuf) -> Result<(), ActionsError> {
         tokio::process::Command::new("unzip")
             .arg(zipfile.display().to_string())
             .arg("-d")

--- a/ghactions-core/src/toolcache/cache.rs
+++ b/ghactions-core/src/toolcache/cache.rs
@@ -226,7 +226,8 @@ mod tests {
 
     fn local_toolcache() -> (PathBuf, ToolCache) {
         // working dir + examples/toolcache
-        let cwd = PathBuf::from(std::env::current_dir().unwrap())
+        let cwd = std::env::current_dir()
+            .unwrap()
             .join("..")
             .canonicalize()
             .unwrap();

--- a/ghactions-core/src/toolcache/tool.rs
+++ b/ghactions-core/src/toolcache/tool.rs
@@ -136,7 +136,7 @@ impl TryFrom<PathBuf> for Tool {
     fn try_from(value: PathBuf) -> Result<Self, Self::Error> {
         let parts: Vec<&str> = value.iter().map(|p| p.to_str().unwrap()).collect();
 
-        let arch = match parts.get(parts.len() - 1) {
+        let arch = match parts.last() {
             Some(arch) => arch,
             None => {
                 return Err(crate::errors::ActionsError::ToolCacheError(
@@ -194,12 +194,13 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_tool_path() {
-        let cwd = PathBuf::from(std::env::current_dir().unwrap())
+        let cwd = std::env::current_dir()
+            .unwrap()
             .join("..")
             .canonicalize()
             .unwrap();
 
-        let toolcache_root = PathBuf::from(cwd.clone());
+        let toolcache_root = cwd.clone();
         let tool_path = Tool::tool_path(&toolcache_root, "node", "12.7.0", ToolCacheArch::X64);
 
         assert_eq!(tool_path, cwd.join("node/12.7.0/x64/"));

--- a/ghactions-derive/src/attributes.rs
+++ b/ghactions-derive/src/attributes.rs
@@ -132,9 +132,12 @@ impl Parse for ActionsAttribute {
                 let lit: LitStr = input.parse()?;
 
                 // TODO: Is this correct?
-                if lit.value().starts_with("..")
+                if (lit.value().starts_with("..")
                     || lit.value().starts_with("./")
-                    || lit.value().starts_with("/")
+                    || (lit.value().starts_with("/")))
+                    && key != Some(ActionsAttributeKeys::Entrypoint)
+                // Only treat as path if it's not a Docker entrypoint, as
+                // we cannot check this for file existence
                 {
                     value_span = Some(lit.span());
                     Some(ActionsAttributeValue::Path(lit.value().into()))

--- a/ghactions-derive/src/attributes.rs
+++ b/ghactions-derive/src/attributes.rs
@@ -277,10 +277,19 @@ impl ActionsAttribute {
                             "Image attribute must have a valid path value (file not found)",
                         ))
                     }
+                } else if let Some(ActionsAttributeValue::String(image_ref)) = &self.value {
+                    if image_ref.starts_with("docker://") {
+                        Ok(())
+                    } else {
+                        Err(syn::Error::new(
+                            self.value_span.unwrap(),
+                            "Image attribute must start with 'docker://'",
+                        ))
+                    }
                 } else {
                     Err(syn::Error::new(
                         self.span.span(),
-                        "Image attribute must have a string value",
+                        "Image attribute must have a string or path value",
                     ))
                 }
             }

--- a/ghactions-derive/src/attributes.rs
+++ b/ghactions-derive/src/attributes.rs
@@ -136,16 +136,8 @@ impl Parse for ActionsAttribute {
                     || lit.value().starts_with("./")
                     || lit.value().starts_with("/")
                 {
-                    if let Ok(v) = std::path::PathBuf::try_from(lit.value()) {
-                        value_span = Some(lit.span());
-
-                        Some(ActionsAttributeValue::Path(v))
-                    } else {
-                        return Err(syn::Error::new(
-                            lit.span(),
-                            format!("Invalid path: {}", lit.value()),
-                        ));
-                    }
+                    value_span = Some(lit.span());
+                    Some(ActionsAttributeValue::Path(lit.value().into()))
                 } else {
                     value_span = Some(lit.span());
                     Some(ActionsAttributeValue::String(lit.value()))

--- a/ghactions-derive/src/attributes.rs
+++ b/ghactions-derive/src/attributes.rs
@@ -219,10 +219,10 @@ impl ActionsAttribute {
                     // TODO: Validate path
                     Ok(())
                 } else if let Some(ActionsAttributeValue::String(_)) = &self.value {
-                    return Err(syn::Error::new(
+                    Err(syn::Error::new(
                         self.value_span.unwrap(),
                         "Path attribute must start with `.` or `/` (e.g. `./action.yml`)",
-                    ));
+                    ))
                 } else {
                     Err(syn::Error::new(
                         self.span.span(),

--- a/ghactions-derive/src/derives/mod.rs
+++ b/ghactions-derive/src/derives/mod.rs
@@ -298,7 +298,16 @@ fn load_actionyaml(attributes: &Vec<ActionsAttribute>) -> Result<ActionYML, syn:
                 action.mode = ActionMode::Container;
 
                 if let Some(ActionsAttributeValue::Path(ref value)) = attr.value {
-                    action.set_container_image(value.to_path_buf());
+                    action.set_container_image(value.display().to_string());
+                } else if let Some(ActionsAttributeValue::String(ref value)) = attr.value {
+                    // Validate the string is not empty
+                    if value.is_empty() {
+                        return Err(syn::Error::new(
+                            attr.value_span.unwrap(),
+                            "Image attribute cannot be empty",
+                        ));
+                    }
+                    action.set_container_image(value.clone());
                 }
             }
             Some(ActionsAttributeKeys::Entrypoint) => {


### PR DESCRIPTION
- the `image` tag can also contain a reference to a prebuilt image like docker://myimagename:latest. Image can now accept String or Path. Path is now only used for checking, then converted back to string.
- entrypoint cannot be reliably checked for file existence, it points into a container.
- fixed latest clippy warnings (1.89)

resolves https://github.com/42ByteLabs/ghactions/issues/80